### PR TITLE
Using isEmpty instead of count for the array pop method

### DIFF
--- a/Stack/Stack.swift
+++ b/Stack/Stack.swift
@@ -19,11 +19,9 @@ public struct Stack<T> {
   }
 
   public mutating func pop() -> T? {
-    if count == 0 {
-      return nil
-    } else {
-      return array.removeLast()
-    }
+    guard !array.isEmpty else { return nil }
+
+    return array.removeLast()
   }
 
   public func peek() -> T? {


### PR DESCRIPTION
Per discussion previously using `isEmpty` on the array instead of `count`