### PR TITLE
Handling empty lists when selecting minimum maximum

### DIFF
--- a/Select Minimum Maximum/Maximum.swift
+++ b/Select Minimum Maximum/Maximum.swift
@@ -1,9 +1,12 @@
 /*
   Finds the maximum value in an array in O(n) time.
-  The array must not be empty.
 */
 
 func maximum<T: Comparable>(var array: [T]) -> T? {
+  guard !array.isEmpty else {
+    return nil
+  }
+  
   var maximum = array.removeFirst()
   for element in array {
     maximum = element > maximum ? element : maximum

--- a/Select Minimum Maximum/Minimum.swift
+++ b/Select Minimum Maximum/Minimum.swift
@@ -1,9 +1,12 @@
 /*
   Finds the minimum value in an array in O(n) time.
-  The array must not be empty.
 */
 
 func minimum<T: Comparable>(var array: [T]) -> T? {
+  guard !array.isEmpty else {
+    return nil
+  }
+
   var minimum = array.removeFirst()
   for element in array {
     minimum = element < minimum ? element : minimum

--- a/Select Minimum Maximum/MinimumMaximumPairs.swift
+++ b/Select Minimum Maximum/MinimumMaximumPairs.swift
@@ -1,10 +1,13 @@
 /*
   Finds the maximum and minimum value in an array in O(n) time.
-  The array must not be empty.
 */
 
-func minimumMaximum<T: Comparable>(var array: [T]) -> (minimum: T, maximum: T)
+func minimumMaximum<T: Comparable>(var array: [T]) -> (minimum: T, maximum: T)?
 {
+  guard !array.isEmpty else {
+    return nil
+  }
+
   var minimum = array.first!
   var maximum = array.first!
 

--- a/Select Minimum Maximum/README.markdown
+++ b/Select Minimum Maximum/README.markdown
@@ -24,6 +24,10 @@ Here is a simple implementation in Swift:
 
 ```swift
 func minimum<T: Comparable>(var array: [T]) -> T? {
+  guard !array.isEmpty else {
+    return nil
+  }
+
   var minimum = array.removeFirst()
   for element in array {
     minimum = element < minimum ? element : minimum
@@ -32,6 +36,10 @@ func minimum<T: Comparable>(var array: [T]) -> T? {
 }
 
 func maximum<T: Comparable>(var array: [T]) -> T? {
+  guard !array.isEmpty else {
+    return nil
+  }
+
   var maximum = array.removeFirst()
   for element in array {
     maximum = element > maximum ? element : maximum
@@ -71,8 +79,12 @@ The result is a minimum of `3` and a maximum of `9`.
 Here is a simple implementation in Swift:
 
 ```swift
-func minimumMaximum<T: Comparable>(var array: [T]) -> (minimum: T, maximum: T)
+func minimumMaximum<T: Comparable>(var array: [T]) -> (minimum: T, maximum: T)?
 {
+  guard !array.isEmpty else {
+    return nil
+  }
+
   var minimum = array.first!
   var maximum = array.first!
 
@@ -109,7 +121,7 @@ Put this code in a playground and test it like so:
 
 ```swift
 
-let result = minimumMaximum(array)
+let result = minimumMaximum(array)!
 result.minimum // This will return 3
 result.maximum // This will return 9
 ```

--- a/Select Minimum Maximum/SelectMinimumMaximum Tests/SelectMinimumMaximumTests/MaximumTests.swift
+++ b/Select Minimum Maximum/SelectMinimumMaximum Tests/SelectMinimumMaximumTests/MaximumTests.swift
@@ -35,6 +35,14 @@ class MaximumTests: XCTestCase {
     XCTAssertEqual(result, 9)
   }
 
+  func testMaximumGivenAnEmptyList() {
+    let array = [Int]()
+
+    let result = maximum(array)
+
+    XCTAssertNil(result)
+  }
+
   func testMaximumMatchesSwiftLibraryGivenARandomList() {
     for _ in 0...10 {
       for n in 1...100 {

--- a/Select Minimum Maximum/SelectMinimumMaximum Tests/SelectMinimumMaximumTests/MinimumTests.swift
+++ b/Select Minimum Maximum/SelectMinimumMaximum Tests/SelectMinimumMaximumTests/MinimumTests.swift
@@ -35,6 +35,14 @@ class MinimumTests: XCTestCase {
     XCTAssertEqual(result, 3)
   }
 
+  func testMinimumGivenAnEmptyList() {
+    let array = [Int]()
+
+    let result = minimum(array)
+
+    XCTAssertNil(result)
+  }
+
   func testMinimumMatchesSwiftLibraryGivenARandomList() {
     for _ in 0...10 {
       for n in 1...100 {

--- a/Select Minimum Maximum/SelectMinimumMaximum Tests/SelectMinimumMaximumTests/SelectMinimumMaximumTests.swift
+++ b/Select Minimum Maximum/SelectMinimumMaximum Tests/SelectMinimumMaximumTests/SelectMinimumMaximumTests.swift
@@ -6,7 +6,7 @@ class SelectMinimumMaximumTests: XCTestCase {
   func testMinimumAndMaximumGivenAListContainingOneElement() {
     let array = [ 8 ]
 
-    let result = minimumMaximum(array)
+    let result = minimumMaximum(array)!
 
     XCTAssertEqual(result.minimum, 8)
     XCTAssertEqual(result.maximum, 8)
@@ -15,7 +15,7 @@ class SelectMinimumMaximumTests: XCTestCase {
   func testMinimumAndMaximumGivenAListContainingMultipleElementsWithTheSameValue() {
     let array = [ 8, 16, 8, 8 ]
 
-    let result = minimumMaximum(array)
+    let result = minimumMaximum(array)!
 
     XCTAssertEqual(result.minimum, 8)
     XCTAssertEqual(result.maximum, 16)
@@ -24,7 +24,7 @@ class SelectMinimumMaximumTests: XCTestCase {
   func testMimimumAndMaximumGivenAListContainingAnEvenNumberOfElements() {
     let array = [ 3, 4, 6, 8 ]
 
-    let result = minimumMaximum(array)
+    let result = minimumMaximum(array)!
 
     XCTAssertEqual(result.minimum, 3)
     XCTAssertEqual(result.maximum, 8)
@@ -33,7 +33,7 @@ class SelectMinimumMaximumTests: XCTestCase {
   func testMimimumAndMaximumGivenAListContainingAnOddNumberOfElements() {
     let array = [ 8, 3, 9, 4, 6 ]
 
-    let result = minimumMaximum(array)
+    let result = minimumMaximum(array)!
 
     XCTAssertEqual(result.minimum, 3)
     XCTAssertEqual(result.maximum, 9)
@@ -42,7 +42,7 @@ class SelectMinimumMaximumTests: XCTestCase {
   func testMimimumAndMaximumGivenAListOfOrderedElements() {
     let array = [ 3, 4, 6, 8, 9 ]
 
-    let result = minimumMaximum(array)
+    let result = minimumMaximum(array)!
 
     XCTAssertEqual(result.minimum, 3)
     XCTAssertEqual(result.maximum, 9)
@@ -51,10 +51,18 @@ class SelectMinimumMaximumTests: XCTestCase {
   func testMimimumAndMaximumGivenAListOfReverseOrderedElements() {
     let array = [ 9, 8, 6, 4, 3 ]
 
-    let result = minimumMaximum(array)
+    let result = minimumMaximum(array)!
 
     XCTAssertEqual(result.minimum, 3)
     XCTAssertEqual(result.maximum, 9)
+  }
+
+  func testMinimumAndMaximumGivenAnEmptyList() {
+    let array = [Int]()
+
+    let result = minimumMaximum(array)
+
+    XCTAssertNil(result)
   }
 
   func testMinimumAndMaximumMatchSwiftLibraryGivenARandomList() {
@@ -62,7 +70,7 @@ class SelectMinimumMaximumTests: XCTestCase {
       for n in 1...100 {
         let array = createRandomList(n)
 
-        let result = minimumMaximum(array)
+        let result = minimumMaximum(array)!
 
         XCTAssertEqual(result.minimum, array.minElement())
         XCTAssertEqual(result.maximum, array.maxElement())

--- a/Select Minimum Maximum/SelectMinimumMaximum.playground/Contents.swift
+++ b/Select Minimum Maximum/SelectMinimumMaximum.playground/Contents.swift
@@ -1,5 +1,9 @@
 // Compare each item to find minimum
 func minimum<T: Comparable>(var array: [T]) -> T? {
+  guard !array.isEmpty else {
+    return nil
+  }
+
   var minimum = array.removeFirst()
   for element in array {
     minimum = element < minimum ? element : minimum
@@ -9,6 +13,10 @@ func minimum<T: Comparable>(var array: [T]) -> T? {
 
 // Compare each item to find maximum
 func maximum<T: Comparable>(var array: [T]) -> T? {
+  guard !array.isEmpty else {
+    return nil
+  }
+
   var maximum = array.removeFirst()
   for element in array {
     maximum = element > maximum ? element : maximum
@@ -17,8 +25,12 @@ func maximum<T: Comparable>(var array: [T]) -> T? {
 }
 
 // Compare in pairs to find minimum and maximum
-func minimumMaximum<T: Comparable>(var array: [T]) -> (minimum: T, maximum: T)
+func minimumMaximum<T: Comparable>(var array: [T]) -> (minimum: T, maximum: T)?
 {
+  guard !array.isEmpty else {
+    return nil
+  }
+
   var minimum = array.first!
   var maximum = array.first!
 
@@ -56,7 +68,7 @@ minimum(array)
 maximum(array)
 
 // Test of minimumMaximum function
-let result = minimumMaximum(array)
+let result = minimumMaximum(array)!
 result.minimum
 result.maximum
 


### PR DESCRIPTION
I've updated the algorithms to handle empty lists. This means the algorithm will return nil when given an empty list which matches the behaviour of the Swift library.

Do you think this should be included? It means we have to add a guard to each algorithm which increases the complexity. I'm not 100% sure if this pull request should be included.