### PR TITLE
Improve Boyer-Moore by always using skipTable to advance cursor

### DIFF
--- a/Boyer-Moore/BoyerMoore.playground/Contents.swift
+++ b/Boyer-Moore/BoyerMoore.playground/Contents.swift
@@ -5,41 +5,38 @@ extension String {
     let patternLength = pattern.characters.count
     assert(patternLength > 0)
     assert(patternLength <= self.characters.count)
-    
+
     var skipTable = [Character: Int]()
     for (i, c) in pattern.characters.enumerate() {
       skipTable[c] = patternLength - i - 1
     }
-    
-    let p = pattern.endIndex.predecessor()
-    let lastChar = pattern[p]
+
     var i = self.startIndex.advancedBy(patternLength - 1)
-    
-    func backwards() -> String.Index? {
-      var q = p
-      var j = i
-      while q > pattern.startIndex {
-        j = j.predecessor()
-        q = q.predecessor()
-        if self[j] != pattern[q] { return nil }
-      }
-      return j
-    }
-    
+
     while i < self.endIndex {
-      let c = self[i]
-      if c == lastChar {
-        if let k = backwards() { return k }
-        i = i.successor()
-      } else {
-        i = i.advancedBy(skipTable[c] ?? patternLength)
+
+      var p = pattern.endIndex.predecessor()
+
+      while p >= pattern.startIndex {
+        let c = self[i]
+
+        if c != pattern[p] {
+          i = i.advancedBy(skipTable[c] ?? patternLength)
+          break
+        }
+
+        if p == pattern.startIndex {
+          return i
+        }
+
+        i = i.predecessor()
+        p = p.predecessor()
       }
     }
+
     return nil
   }
 }
-
-
 
 // A few simple tests
 

--- a/Boyer-Moore/BoyerMoore.playground/Contents.swift
+++ b/Boyer-Moore/BoyerMoore.playground/Contents.swift
@@ -21,7 +21,7 @@ extension String {
         let c = self[i]
 
         if c != pattern[p] {
-          i = i.advancedBy(skipTable[c] ?? patternLength)
+          i = i.advancedBy(skipTable[c] ?? patternLength, limit: self.endIndex)
           break
         }
 

--- a/Boyer-Moore/BoyerMoore.swift
+++ b/Boyer-Moore/BoyerMoore.swift
@@ -40,7 +40,7 @@ extension String {
           // pattern, we can skip ahead by the full pattern length. However, if
           // the character *is* present in the pattern, there may be a match up
           // ahead and we can't skip as far.
-          i = i.advancedBy(skipTable[c] ?? patternLength)
+          i = i.advancedBy(skipTable[c] ?? patternLength, limit: self.endIndex)
           break
         }
 

--- a/Boyer-Moore/BoyerMoore.swift
+++ b/Boyer-Moore/BoyerMoore.swift
@@ -12,58 +12,48 @@ extension String {
     let patternLength = pattern.characters.count
     assert(patternLength > 0)
     assert(patternLength <= self.characters.count)
-    
+
     // Make the skip table. This table determines how far we skip ahead
     // when a character from the pattern is found.
     var skipTable = [Character: Int]()
     for (i, c) in pattern.characters.enumerate() {
       skipTable[c] = patternLength - i - 1
     }
-    
-    // This points at the last character in the pattern.
-    let p = pattern.endIndex.predecessor()
-    let lastChar = pattern[p]
-    
+
     // The pattern is scanned right-to-left, so skip ahead in the string by
     // the length of the pattern. (Minus 1 because startIndex already points
     // at the first character in the source string.)
     var i = self.startIndex.advancedBy(patternLength - 1)
-    
-    // This is a helper function that steps backwards through both strings 
-    // until we find a character that doesn’t match, or until we’ve reached
-    // the beginning of the pattern.
-    func backwards() -> String.Index? {
-      var q = p
-      var j = i
-      while q > pattern.startIndex {
-        j = j.predecessor()
-        q = q.predecessor()
-        if self[j] != pattern[q] { return nil }
-      }
-      return j
-    }
-    
+
     // The main loop. Keep going until the end of the string is reached.
     while i < self.endIndex {
-      let c = self[i]
-      
-      // Does the current character match the last character from the pattern?
-      if c == lastChar {
-        
-        // There is a possible match. Do a brute-force search backwards.
-        if let k = backwards() { return k }
-        
-        // If no match, we can only safely skip one character ahead.
-        i = i.successor()
-      } else {
-        // The characters are not equal, so skip ahead. The amount to skip is
-        // determined by the skip table. If the character is not present in the
-        // pattern, we can skip ahead by the full pattern length. However, if
-        // the character *is* present in the pattern, there may be a match up
-        // ahead and we can't skip as far.
-        i = i.advancedBy(skipTable[c] ?? patternLength)
+
+      // This points at the last character in the pattern.
+      var p = pattern.endIndex.predecessor()
+
+      while p >= pattern.startIndex {
+        let c = self[i]
+
+        if c != pattern[p] {
+          // The characters are not equal, so skip ahead. The amount to skip is
+          // determined by the skip table. If the character is not present in the
+          // pattern, we can skip ahead by the full pattern length. However, if
+          // the character *is* present in the pattern, there may be a match up
+          // ahead and we can't skip as far.
+          i = i.advancedBy(skipTable[c] ?? patternLength)
+          break
+        }
+
+        if p == pattern.startIndex {
+          // All patterns matched.
+          return i
+        }
+
+        i = i.predecessor()
+        p = p.predecessor()
       }
     }
+
     return nil
   }
 }

--- a/Boyer-Moore/README.markdown
+++ b/Boyer-Moore/README.markdown
@@ -46,50 +46,40 @@ extension String {
       skipTable[c] = patternLength - i - 1
     }
 
-    // This points at the last character in the pattern.
-    let p = pattern.endIndex.predecessor()
-    let lastChar = pattern[p]
-
     // The pattern is scanned right-to-left, so skip ahead in the string by
     // the length of the pattern. (Minus 1 because startIndex already points
     // at the first character in the source string.)
     var i = self.startIndex.advancedBy(patternLength - 1)
 
-    // This is a helper function that steps backwards through both strings 
-    // until we find a character that doesn’t match, or until we’ve reached
-    // the beginning of the pattern.
-    func backwards() -> String.Index? {
-      var q = p
-      var j = i
-      while q > pattern.startIndex {
-        j = j.predecessor()
-        q = q.predecessor()
-        if self[j] != pattern[q] { return nil }
-      }
-      return j
-    }
-
     // The main loop. Keep going until the end of the string is reached.
     while i < self.endIndex {
-      let c = self[i]
 
-      // Does the current character match the last character from the pattern?
-      if c == lastChar {
+      // This points at the last character in the pattern.
+      var p = pattern.endIndex.predecessor()
 
-        // There is a possible match. Do a brute-force search backwards.
-        if let k = backwards() { return k }
+      while p >= pattern.startIndex {
+        let c = self[i]
 
-        // If no match, we can only safely skip one character ahead.
-        i = i.successor()
-      } else {
-        // The characters are not equal, so skip ahead. The amount to skip is
-        // determined by the skip table. If the character is not present in the
-        // pattern, we can skip ahead by the full pattern length. However, if
-        // the character *is* present in the pattern, there may be a match up
-        // ahead and we can't skip as far.
-        i = i.advancedBy(skipTable[c] ?? patternLength)
+        if c != pattern[p] {
+          // The characters are not equal, so skip ahead. The amount to skip is
+          // determined by the skip table. If the character is not present in the
+          // pattern, we can skip ahead by the full pattern length. However, if
+          // the character *is* present in the pattern, there may be a match up
+          // ahead and we can't skip as far.
+          i = i.advancedBy(skipTable[c] ?? patternLength)
+          break
+        }
+
+        if p == pattern.startIndex {
+          // All patterns matched.
+          return i
+        }
+
+        i = i.predecessor()
+        p = p.predecessor()
       }
     }
+
     return nil
   }
 }

--- a/Boyer-Moore/README.markdown
+++ b/Boyer-Moore/README.markdown
@@ -66,7 +66,7 @@ extension String {
           // pattern, we can skip ahead by the full pattern length. However, if
           // the character *is* present in the pattern, there may be a match up
           // ahead and we can't skip as far.
-          i = i.advancedBy(skipTable[c] ?? patternLength)
+          i = i.advancedBy(skipTable[c] ?? patternLength, limit: self.endIndex)
           break
         }
 


### PR DESCRIPTION
```swift
// If no match, we can only safely skip one character ahead.		
// The characters are not equal, so skip ahead. The amount to skip is
i = i.successor()
```

I think this is inefficient and you can always use `skipTable` to skip many characters.